### PR TITLE
add variable time window for schedule

### DIFF
--- a/src/plan/Schedule.js
+++ b/src/plan/Schedule.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Grid from '@material-ui/core/Grid';
 import ScheduleBlocks from './ScheduleBlocks'
-import { convertTime24to12, getEarliestLatestTimes } from '../util/util'
+import { convertTime24to12, getTimeWindow } from '../util/util'
 
 export default class Schedule extends React.Component {
     constructor(props) {
@@ -19,11 +19,11 @@ export default class Schedule extends React.Component {
         const defaultStartTime = 1000;
         const defaultEndTime = 1600;
 
-        let timeWindow = getEarliestLatestTimes(sections);
+        let timeWindow = getTimeWindow(sections);
         let earliestStartTime = Math.min(timeWindow.start, defaultStartTime);
         let latestEndTime = Math.max(timeWindow.end, defaultEndTime);
 
-        let startHour= earliestStartTime/100;
+        let startHour = earliestStartTime/100;
         let endHour = latestEndTime/100;
 
         const numCols = 6;

--- a/src/plan/Schedule.js
+++ b/src/plan/Schedule.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Grid from '@material-ui/core/Grid';
 import ScheduleBlocks from './ScheduleBlocks'
-import { convertTime24to12 } from '../util/util'
+import { convertTime24to12, getEarliestLatestTimes } from '../util/util'
 
 export default class Schedule extends React.Component {
     constructor(props) {
@@ -19,13 +19,21 @@ export default class Schedule extends React.Component {
         const defaultStartTime = 1000;
         const defaultEndTime = 1600;
 
-        let startHour= defaultStartTime/100;
-        let endHour = defaultEndTime/100;
+        let timeWindow = getEarliestLatestTimes(sections);
+        console.log('getEarliestLatestTimes(sections)');
+        console.log(timeWindow);
+        let earliestStartTime = Math.min(timeWindow.start, defaultStartTime);
+        let latestEndTime = Math.max(timeWindow.end, defaultEndTime);
+
+        let startHour= earliestStartTime/100;
+        let endHour = latestEndTime/100;
 
         const numCols = 6;
         const numRows = (endHour - startHour + 1) * 12;
         console.log('numRows: ' + numRows); 
 
+        // labels
+        // =========
         // x-axis labels for days
         let dayLabels = [];
         let days = ["Mon", "Tue", "Wed", "Thur", "Fri"];
@@ -43,7 +51,9 @@ export default class Schedule extends React.Component {
             </span>
             )
         }
+
         // grid lines
+        // =============
         let gridLines = [];
         // x-axis
         for(let i = 0; i < numRows - 1; i++) {

--- a/src/plan/Schedule.js
+++ b/src/plan/Schedule.js
@@ -20,8 +20,6 @@ export default class Schedule extends React.Component {
         const defaultEndTime = 1600;
 
         let timeWindow = getEarliestLatestTimes(sections);
-        console.log('getEarliestLatestTimes(sections)');
-        console.log(timeWindow);
         let earliestStartTime = Math.min(timeWindow.start, defaultStartTime);
         let latestEndTime = Math.max(timeWindow.end, defaultEndTime);
 

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -1,3 +1,35 @@
+// Returns the earliest start time and latest end time in an array of sections
+// e.g. {start: 900, end: 1650}
+export const getEarliestLatestTimes = (sections) => {
+    let earliestStartTime = 2400;
+    let latestEndTime = 0;
+
+    sections.forEach(section => {
+        section.meeting_times.forEach(meeting => {
+            console.log('section.meeting_times:');
+            console.log(meeting);
+
+            let times = parseStartEndFromTimeblock(meeting.time);
+            let start = parseInt(times.start);
+            let end = parseInt(times.end);
+
+            if(start < earliestStartTime) {
+                earliestStartTime = start;
+            }
+            if (end > latestEndTime) {
+                latestEndTime = end;
+            }
+        })
+    });
+
+    let res = {
+        start: earliestStartTime,
+        end: latestEndTime,
+    }
+
+    return res;
+}
+
 // Returns start and end times in 24-hour format 
 // e.g. {start: 1000, end: 1150}
 export const parseStartEndFromTimeblock = (timeblock) => {

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -1,6 +1,6 @@
 // Returns the earliest start time and latest end time in an array of sections
 // e.g. {start: 900, end: 1650}
-export const getEarliestLatestTimes = (sections) => {
+export const getTimeWindow = (sections) => {
     let earliestStartTime = 2400;
     let latestEndTime = 0;
 

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -6,9 +6,6 @@ export const getTimeWindow = (sections) => {
 
     sections.forEach(section => {
         section.meeting_times.forEach(meeting => {
-            console.log('section.meeting_times:');
-            console.log(meeting);
-
             let times = parseStartEndFromTimeblock(meeting.time);
             let start = parseInt(times.start);
             let end = parseInt(times.end);


### PR DESCRIPTION
This change adds dynamic resizing to the right-hand `Schedule` view based on the selected sections' start and end times.